### PR TITLE
include SnappyTargets.cmake for easier integration, in SnappyConfig.c…

### DIFF
--- a/deps/snappy/snappy-1.1.7/cmake/SnappyConfig.cmake
+++ b/deps/snappy/snappy-1.1.7/cmake/SnappyConfig.cmake
@@ -1,1 +1,3 @@
+# Include the 'SnappyTargets.cmake' file located in the same directory as this file.
+# This will load additional configuration and target settings related to Snappy.
 include("${CMAKE_CURRENT_LIST_DIR}/SnappyTargets.cmake")


### PR DESCRIPTION
…make file

Included the SnappyTargets.cmake file in SnappyConfig.cmake to streamline the integration of the Snappy library in other CMake-based projects.

- This change ensures that `SnappyTargets.cmake` is loaded automatically when the SnappyConfig.cmake is included.
- By including `SnappyTargets.cmake`, the build configuration for Snappy, such as target definitions, compiler flags, and paths, will be set up correctly when Snappy is used in other projects.
- This simplifies the process of linking Snappy with other projects, allowing CMake to manage all necessary configurations without requiring manual path and setting adjustments.

This update improves the ease of integrating Snappy with other projects by leveraging CMake's `find_package()` functionality.